### PR TITLE
Allow variable cells to scroll instead of exploding the table height

### DIFF
--- a/src/web/nextui/src/app/eval/ResultsTable.css
+++ b/src/web/nextui/src/app/eval/ResultsTable.css
@@ -63,6 +63,11 @@ table.results-table,
   background-color: var(--variable-background-color);
 }
 
+.variable .cell {
+  max-height: 100%;
+  overflow-y: auto;
+}
+
 .results-table tr.header {
   background-color: var(--header-background-color);
 }


### PR DESCRIPTION
This was driving me mad, as (as a user) I am primarily focussed on the output, not the (sometimes many) input variables. This allows the variable cells to scroll vertically if they exceed the height of the rest of the table.